### PR TITLE
Move public headers out of `details`

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ This will:
 
 (Note that tests and docs will remain in the build directory.)
 
-Since lucenaBAL is a header-only library, it is not necessary to link it; simply `#include <lucenaBAL/lucenaBAL.hpp>` where you need feature tests. Usage information is available in the [online docs](https://bitweeder.github.io/lucenaBAL/html/index.html), as well as in the headers themselves (primarily in  `<lucenaBAL/details/lbalFeatureSetup.hpp>`).
+Since lucenaBAL is a header-only library, it is not necessary to link it; simply `#include <lucenaBAL/lucenaBAL.hpp>` where you need feature tests. Usage information is available in the [online docs](https://bitweeder.github.io/lucenaBAL/html/index.html), as well as in the headers themselves (primarily in  `<lucenaBAL/lbalFeatureSetup.hpp>`).
 
 ## Prerequisites
 

--- a/include/lucenaBAL/details/compilers/lbalAppleClangInitialization.hpp
+++ b/include/lucenaBAL/details/compilers/lbalAppleClangInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectCompiler.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/compilers/lbalAppleClangPostInitialization.hpp
+++ b/include/lucenaBAL/details/compilers/lbalAppleClangPostInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectCompiler.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/compilers/lbalClangInitialization.hpp
+++ b/include/lucenaBAL/details/compilers/lbalClangInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectCompiler.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/compilers/lbalClangPostInitialization.hpp
+++ b/include/lucenaBAL/details/compilers/lbalClangPostInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectCompiler.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/compilers/lbalGCCInitialization.hpp
+++ b/include/lucenaBAL/details/compilers/lbalGCCInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectCompiler.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/compilers/lbalGCCPostInitialization.hpp
+++ b/include/lucenaBAL/details/compilers/lbalGCCPostInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectCompiler.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/compilers/lbalMSVCInitialization.hpp
+++ b/include/lucenaBAL/details/compilers/lbalMSVCInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectCompiler.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/compilers/lbalMSVCPostInitialization.hpp
+++ b/include/lucenaBAL/details/compilers/lbalMSVCPostInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectCompiler.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/lbalCompilerSetup.hpp
+++ b/include/lucenaBAL/details/lbalCompilerSetup.hpp
@@ -15,7 +15,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectCompiler.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/lbalDefinitionTests.hpp
+++ b/include/lucenaBAL/details/lbalDefinitionTests.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 
 
 /*------------------------------------------------------------------------------

--- a/include/lucenaBAL/details/lbalDetectCompiler.hpp
+++ b/include/lucenaBAL/details/lbalDetectCompiler.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 
 

--- a/include/lucenaBAL/details/lbalDetectStandardLibrary.hpp
+++ b/include/lucenaBAL/details/lbalDetectStandardLibrary.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalCompilerSetup.hpp>
 
 

--- a/include/lucenaBAL/details/lbalLibrarySetup.hpp
+++ b/include/lucenaBAL/details/lbalLibrarySetup.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalCompilerSetup.hpp>
 #include <lucenaBAL/details/lbalDetectStandardLibrary.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>

--- a/include/lucenaBAL/details/lbalPlatformSetup.hpp
+++ b/include/lucenaBAL/details/lbalPlatformSetup.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 
 
 /*------------------------------------------------------------------------------

--- a/include/lucenaBAL/details/lbalVersionSetup.hpp
+++ b/include/lucenaBAL/details/lbalVersionSetup.hpp
@@ -19,7 +19,7 @@
 //	__SEEME__ We load this first, for once, since some of its macros are needed
 //	for the following evaluation. This will have no impact on how any
 //	subsequently-included std headers are evaluated.
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalCompilerSetup.hpp>
 
 

--- a/include/lucenaBAL/details/libraries/lbalStandardLibraryAppleLibCppInitialization.hpp
+++ b/include/lucenaBAL/details/libraries/lbalStandardLibraryAppleLibCppInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectStandardLibrary.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 #include <lucenaBAL/details/lbalVersionSetup.hpp>

--- a/include/lucenaBAL/details/libraries/lbalStandardLibraryAppleLibCppPostInitialization.hpp
+++ b/include/lucenaBAL/details/libraries/lbalStandardLibraryAppleLibCppPostInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectStandardLibrary.hpp>
 
 

--- a/include/lucenaBAL/details/libraries/lbalStandardLibraryLibCppInitialization.hpp
+++ b/include/lucenaBAL/details/libraries/lbalStandardLibraryLibCppInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectStandardLibrary.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 #include <lucenaBAL/details/lbalVersionSetup.hpp>

--- a/include/lucenaBAL/details/libraries/lbalStandardLibraryLibCppPostInitialization.hpp
+++ b/include/lucenaBAL/details/libraries/lbalStandardLibraryLibCppPostInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectStandardLibrary.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/libraries/lbalStandardLibraryLibStdCppInitialization.hpp
+++ b/include/lucenaBAL/details/libraries/lbalStandardLibraryLibStdCppInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectStandardLibrary.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 #include <lucenaBAL/details/lbalVersionSetup.hpp>

--- a/include/lucenaBAL/details/libraries/lbalStandardLibraryLibStdCppPostInitialization.hpp
+++ b/include/lucenaBAL/details/libraries/lbalStandardLibraryLibStdCppPostInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectStandardLibrary.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/libraries/lbalStandardLibraryMSVCInitialization.hpp
+++ b/include/lucenaBAL/details/libraries/lbalStandardLibraryMSVCInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectStandardLibrary.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 #include <lucenaBAL/details/lbalVersionSetup.hpp>

--- a/include/lucenaBAL/details/libraries/lbalStandardLibraryMSVCPostInitialization.hpp
+++ b/include/lucenaBAL/details/libraries/lbalStandardLibraryMSVCPostInitialization.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDetectStandardLibrary.hpp>
 #include <lucenaBAL/details/lbalKnownVersions.hpp>
 

--- a/include/lucenaBAL/details/platforms/lbalPlatformApple.hpp
+++ b/include/lucenaBAL/details/platforms/lbalPlatformApple.hpp
@@ -28,7 +28,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 
 
 /*------------------------------------------------------------------------------

--- a/include/lucenaBAL/details/platforms/lbalPlatformPOSIX.hpp
+++ b/include/lucenaBAL/details/platforms/lbalPlatformPOSIX.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 
 
 /*------------------------------------------------------------------------------

--- a/include/lucenaBAL/details/platforms/lbalPlatformWinAPI.hpp
+++ b/include/lucenaBAL/details/platforms/lbalPlatformWinAPI.hpp
@@ -17,7 +17,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 
 
 /*------------------------------------------------------------------------------

--- a/include/lucenaBAL/lbalConfig.hpp
+++ b/include/lucenaBAL/lbalConfig.hpp
@@ -11,7 +11,7 @@
 ------------------------------------------------------------------------------*/
 
 /**
-	@file lucenaBAL/details/lbalConfig.hpp
+	@file lucenaBAL/lbalConfig.hpp
 
 	@brief Documents the internal options used in a given build of lucenaBAL.
 
@@ -25,6 +25,9 @@
 	global settings may also be documented here, as well as certain situational
 	settings. Such settings should typically be set in the client code’s own
 	headers.
+
+	@remarks Do not include this header directly. It is public explicitly to
+	expose it for configuration and formalize it as part of the interface.
 */
 
 

--- a/include/lucenaBAL/lbalFeatureSetup.hpp
+++ b/include/lucenaBAL/lbalFeatureSetup.hpp
@@ -10,11 +10,26 @@
 
 ------------------------------------------------------------------------------*/
 
+/**
+	@file lucenaBAL/lbalFeatureSetup.hpp
+
+	@brief Documents the complete set of feature macros defined by lucenaBAL
+
+	@details Tokens described herein may be considered part of the public
+	interface of lucenaBAL. An effort will be made to maintain these in a
+	stable fashion in keeping with the principles of
+	[semantic versioning](https://semver.org/).
+
+	@remarks Do not include this header directly. It is intended only to
+	document the public interface of lucenaBAL.
+*/
+
+
 #pragma once
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 #include <lucenaBAL/details/lbalDefinitionTests.hpp>
 #include <lucenaBAL/details/lbalPlatformSetup.hpp>
 #include <lucenaBAL/details/lbalCompilerSetup.hpp>

--- a/include/lucenaBAL/lucenaBAL.hpp
+++ b/include/lucenaBAL/lucenaBAL.hpp
@@ -111,5 +111,5 @@
 	@defgroup lbal_decorators Linker Decorators
 */
 
-#include <lucenaBAL/details/lbalConfig.hpp>
-#include <lucenaBAL/details/lbalFeatureSetup.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
+#include <lucenaBAL/lbalFeatureSetup.hpp>

--- a/test/lbalTestConfig.hpp
+++ b/test/lbalTestConfig.hpp
@@ -15,7 +15,7 @@
 
 
 //	lbal
-#include <lucenaBAL/details/lbalConfig.hpp>
+#include <lucenaBAL/lbalConfig.hpp>
 	//	This file MUST be included first.
 
 


### PR DESCRIPTION
This formally exposes the public interface of lucenaBAL for the purpose of clarifying what is public and what is not. Note that these change do not break ABI or change the API in any way.